### PR TITLE
Fix link to Research and Projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
               <a class="nav-link js-scroll-trigger" href="#about">AboutMe</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link js-scroll-trigger" href="#research&Projects">Research/Projects</a>
+              <a class="nav-link js-scroll-trigger" href="#research_projects">Research/Projects</a>
             </li>
 			<li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">ContectMe</a>
@@ -140,7 +140,7 @@
         </div><!-- end container -->
     </div><!-- end section -->
 	
-    <div id="Research/Projects" class="section lb">
+    <div id="research_projects" class="section lb">
         <div class="container">
             <div class="section-title text-left">
                 <h3>Research and Projects</h3>


### PR DESCRIPTION
The "Research / Projects" link at https://luwang823.github.io/ is broken. This is due to a mismatch between the `id` attribute of the corresponding section and the invalidity of the identifier values.

This PR fixes the issue and allows the link to work as expected. A demo of the difference can be see at https://machawk1.github.io/LuWang823.github.io as compared to https://luwang823.github.io/ .

/cc @LuWang823 